### PR TITLE
Issue with "sitecode" parameter for the "Get-sccmsession" function

### DIFF
--- a/PowerSCCM.ps1
+++ b/PowerSCCM.ps1
@@ -309,7 +309,7 @@ function Get-SccmSession {
 
         [Parameter(ValueFromPipelineByPropertyName=$True)]
         [String]
-        [ValidatePattern('^[A-Za-z]{3}$')]
+        [ValidatePattern('^[A-Za-z0-9]{3}$')]
         $SiteCode,
 
         [Parameter(ValueFromPipelineByPropertyName=$True)]


### PR DESCRIPTION
For the Get-sccmsession function, the regular expression used to validate the "sitecode" parameter needs to be changed to include integers as well.  The company I work for uses SCCM, and the last character in the site code is an integer, so even if I am able to create an session with "New-sccmsession", if I were to run "Get-sccmsession -session $session -sitecode $mycompanyssitecode", the function would generate an error because the site code fails the regular expression given in "ValidatePattern."  My change resolves this issue.